### PR TITLE
Negative margin

### DIFF
--- a/pg_sequence_fixer--1.0.sql
+++ b/pg_sequence_fixer--1.0.sql
@@ -1,5 +1,5 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
---\echo Use "CREATE EXTENSION pg_sequence_fixer" to load this file. \quit
+\echo Use "CREATE EXTENSION pg_sequence_fixer" to load this file. \quit
 
 CREATE OR REPLACE FUNCTION pg_sequence_fixer(IN v_margin int, IN v_lock_mode boolean DEFAULT false)
 RETURNS void AS


### PR DESCRIPTION
This adds a few little improvements:
- in the case of a negative margin (as well as too big margin) there is the chance that the final value to set the sequence at is out of boundaries, so I tried to catch those cases;
- the user must have the right privileges to operate on the sequence, otherwise it skips the sequence and moves on;
- in the case the target table is empty, the `v_max` value will be `NULL`, so the sequence must be restarted instead of trying to set a `NULL` value.

I am also wondering if it does not make more sense to provide this as a procedure, or at least as both a procedure and a function.